### PR TITLE
ci: use semver for docker tags

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -41,7 +41,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=test,enable={{is_default_branch}}
-            type=pep440,pattern={{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3

--- a/.github/workflows/test:e2e.yml
+++ b/.github/workflows/test:e2e.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Checkout full-msg-protocol-infra repo
+      - name: Checkout local-erc20-messaging-infra repo
         uses: actions/checkout@v3
         with:
           repository: topos-network/local-erc20-messaging-infra


### PR DESCRIPTION
# Description

This PR replaces `pep440` with `semver` for the docker tag strategy in the CI workflow.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
