### PR TITLE
ci: notify new release on slack

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,0 +1,20 @@
+name: Release Pipeline
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "repository": "${{ github.repository }}",
+              "version": "${{ github.ref }}",
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ vars.RELEASE_PIPELINE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Description

This PR adds a new CI workflow that will send a message on Slack to announce releases. This is to facilitate the upcoming new e2e test architecture with the new `topos-network/e2e-tests` centralized repository.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
