### PR TITLE
ci: run e2e tests from new remote repo

### DIFF
--- a/.github/workflows/test:e2e.yml
+++ b/.github/workflows/test:e2e.yml
@@ -5,91 +5,16 @@ on:
     branches:
       - main
 
-env:
-  LOCAL_ERC20_MESSAGING_INFRA_VERSION: v0.1.0-alpha
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    environment: devnet-1
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Checkout local-erc20-messaging-infra repo
-        uses: actions/checkout@v3
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          repository: topos-network/local-erc20-messaging-infra
-          ref: ${{ env.LOCAL_ERC20_MESSAGING_INFRA_VERSION }}
-          path: infra
-
-      - name: Start containers
-        run: >
-          cd infra &&
-          cat .env &&
-          docker compose --profile executor-service up -d
-        env:
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-          TOKEN_DEPLOYER_SALT: ${{ secrets.TOKEN_DEPLOYER_SALT }}
-          TOPOS_CORE_SALT: ${{ secrets.TOPOS_CORE_SALT }}
-          TOPOS_CORE_PROXY_SALT: ${{ secrets.TOPOS_CORE_PROXY_SALT }}
-          ERC20_MESSAGING_SALT: ${{ secrets.ERC20_MESSAGING_SALT }}
-          SUBNET_REGISTRATOR_SALT: ${{ secrets.SUBNET_REGISTRATOR_SALT }}
-
-      - name: Debug containers
-        if: failure()
-        run: docker inspect contracts-edena | grep Image && docker logs contracts-edena
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-
-      - name: Install npm packages
-        run: npm ci
-
-      - name: Install linux deps
-        run: |
-          sudo apt-get install --no-install-recommends -y \
-          fluxbox \
-          xvfb
-
-      - name: Build frontend
-        run: npm run frontend:build
-        env:
-          VITE_ERC20_MESSAGING_CONTRACT_ADDRESS: ${{ vars.VITE_ERC20_MESSAGING_CONTRACT_ADDRESS }}
-          VITE_EXECUTOR_SERVICE_ENDPOINT: ${{ vars.VITE_EXECUTOR_SERVICE_ENDPOINT }}
-          VITE_SUBNET_REGISTRATOR_CONTRACT_ADDRESS: ${{ vars.VITE_SUBNET_REGISTRATOR_CONTRACT_ADDRESS }}
-          VITE_TOPOS_CORE_CONTRACT_ADDRESS: ${{ vars.VITE_TOPOS_CORE_CONTRACT_ADDRESS }}
-          VITE_TOPOS_SUBNET_ENDPOINT: ${{ vars.VITE_TOPOS_SUBNET_ENDPOINT }}
-          VITE_TRACING_OTEL_COLLECTOR_ENDPOINT: ${{ vars.VITE_TRACING_OTEL_COLLECTOR_ENDPOINT }}
-          VITE_TRACING_SERVICE_NAME: ${{ vars.VITE_TRACING_SERVICE_NAME }}
-          VITE_TRACING_SERVICE_VERSION: ${{ vars.VITE_TRACING_SERVICE_VERSION }}
-
-      - name: Run E2E tests
-        run: |
-          Xvfb :0 -screen 0 1024x768x24 -listen tcp -ac &
-          fluxbox &
-          npm run test:e2e
-        env:
-          AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-          AUTH0_ISSUER_URL: ${{ secrets.AUTH0_ISSUER_URL }}
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-          CYPRESS_REMOTE_DEBUGGING_PORT: ${{ vars.CYPRESS_REMOTE_DEBUGGING_PORT }}
-          PORT: 3001
-          DISPLAY: :0.0
-
-      - name: Debug executor service
-        if: failure()
-        run: docker logs executor-service
-
-      - name: Archive e2e artifacts
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: e2e-artifacts
-          path: |
-            packages/frontend/cypress/videos
-            packages/frontend/cypress/screenshots
-        continue-on-error: true
+          owner: topos-network
+          repo: e2e-tests
+          github_token: ${{ secrets.ROBOT_PAT_TRIGGER_E2E_WORKFLOWS }}
+          workflow_file_name: frontend:erc20-messaging.yml
+          ref: main
+          wait_interval: 60
+          client_payload: '{ "dapp-frontend-erc20-messaging-version": "${{ github.head_ref }}" }'


### PR DESCRIPTION
# Description

This PR removes the local e2e tests workflow content and instead triggers the same logic remotely using the new `topos-network/e2e-tests` repository.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
