### PR TITLE
test: wait longer for the final tx

### DIFF
--- a/.github/workflows/test:e2e.yml
+++ b/.github/workflows/test:e2e.yml
@@ -17,4 +17,4 @@ jobs:
           workflow_file_name: frontend:erc20-messaging.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "dapp-frontend-erc20-messaging-version": "${{ github.head_ref }}" }'
+          client_payload: '{ "dapp-frontend-erc20-messaging-ref": "${{ github.head_ref }}" }'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dapp-frontend-cross-subnet",
+  "name": "@topos-network/dapp-frontend-erc20-messaging",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dapp-frontend-cross-subnet",
+      "name": "@topos-network/dapp-frontend-erc20-messaging",
       "version": "1.0.0",
       "license": "MIT",
       "workspaces": [

--- a/packages/frontend/cypress/e2e/step2.cy.ts
+++ b/packages/frontend/cypress/e2e/step2.cy.ts
@@ -74,7 +74,7 @@ describe('Multistep form step-2', () => {
     cy.get('#executeStep2').find('.ant-spin').should('be.visible')
     cy.get('#executeStep0').find('.ant-spin').should('not.exist')
     cy.get('#executeStep1').find('.ant-spin').should('not.exist')
-    cy.get('.ant-result-success')
+    cy.get('.ant-result-success', { timeout: 60000 })
       .find('.ant-result-subtitle')
       .should('be.visible')
       .and('have.text', 'Transaction was submitted on Incal')


### PR DESCRIPTION
# Description

This PR introduces a custom longer timeout for the final erc20 token transfer transaction as currently tests sometimes fail.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
